### PR TITLE
[FEAT] Add route to list all available scripts 

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -12,6 +12,12 @@ import (
 	"github.com/labstack/echo"
 )
 
+// ScriptOutput is the struct being used into the output of route /scripts/:type
+type ScriptOutput struct {
+	ID    int
+	Title string
+}
+
 // HealthCheck is the heath check function.
 func HealthCheck(c echo.Context) error {
 	return c.String(http.StatusOK, "WORKING!\n")
@@ -43,6 +49,47 @@ func ReceiveInstallRequest(c echo.Context) error {
 	// ServiceScript ID is hit but Vulnaas do not know the package manager to do the correct redirect.
 	errMsg := fmt.Sprintf("echo \"[x][VulnaaS] %d is a ServiceScript. Use http://%s:%s/scripts/:pm/%d instead.\"", installScript.ID, config.APIhost, config.APIport, installScript.ID)
 	return c.String(http.StatusOK, errMsg)
+}
+
+// ListScripts returns all scripts' title and ID given a type (all, vulnaas and service)
+func ListScripts(c echo.Context) error {
+
+	typeScript := c.Param("type")
+	var scriptInfo ScriptOutput
+	output := []ScriptOutput{}
+
+	switch typeScript {
+	case "all":
+		for _, script := range config.VulnaasConfig.VulnaasScripts {
+			scriptInfo.ID = script.ID
+			scriptInfo.Title = script.Title
+			output = append(output, scriptInfo)
+		}
+		for _, script := range config.VulnaasConfig.ServiceScripts {
+			scriptInfo.ID = script.ID
+			scriptInfo.Title = script.Title
+			output = append(output, scriptInfo)
+		}
+		return c.JSON(http.StatusOK, output)
+	case "vulnaas":
+		for _, script := range config.VulnaasConfig.VulnaasScripts {
+			scriptInfo.ID = script.ID
+			scriptInfo.Title = script.Title
+			output = append(output, scriptInfo)
+		}
+		return c.JSON(http.StatusOK, output)
+	case "services":
+		for _, script := range config.VulnaasConfig.ServiceScripts {
+			scriptInfo.ID = script.ID
+			scriptInfo.Title = script.Title
+			output = append(output, scriptInfo)
+		}
+		return c.JSON(http.StatusOK, output)
+	default:
+		errMsg := fmt.Sprintf("echo \"[x][VulnaaS] Type %s invalid.\"", typeScript)
+		return c.String(http.StatusOK, errMsg)
+	}
+
 }
 
 // InstallScript returns a script based on its ID and its package manager.

--- a/server.go
+++ b/server.go
@@ -40,6 +40,8 @@ func main() {
 
 	echoInstance.GET("/healthcheck", api.HealthCheck)
 	echoInstance.GET("/install/:input", api.ReceiveInstallRequest)
+
+	echoInstance.GET("/scripts/:type", api.ListScripts)
 	echoInstance.GET("/scripts/:pm/:input", api.InstallScript)
 
 	vulnaasAPIPort := fmt.Sprintf(":%d", getAPIPort())


### PR DESCRIPTION
## Closes issue #12 

#### api/routes.go:
* Added `ListScripts` that returns all scripts' title and ID given a type (all, vulnaas and service).

#### server.go:
* Added a new echo route: `echoInstance.GET("/scripts/:type", api.ListScripts)` 